### PR TITLE
Fixed cmake warning that targets shouldn't be named test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ add_library(tinyobjloader
 			${tinyobjloader-Source}
 	)
 
-add_executable(test ${tinyobjloader-Test-Source})
-target_link_libraries(test tinyobjloader)
+add_executable(test_loader ${tinyobjloader-Test-Source})
+target_link_libraries(test_loader tinyobjloader)
 
 add_executable(obj_sticher ${tinyobjloader-examples-objsticher})
 target_link_libraries(obj_sticher tinyobjloader)


### PR DESCRIPTION
Fixed an issue with new behaviour in cmake 3.0.0 according to this policy:

> Target names reserved by one or more CMake generators are not allowed.
> Among others these include "all", "help" and "test".
> The OLD behavior for this policy is to allow creating targets with
> reserved names or which do not match the validity pattern.

> The NEW behavior for this policy is to report an error
> if an add_* command is used with an invalid target name.
> This policy was introduced in CMake version 3.0.  CMake version
> 3.0.0 warns when the policy is not set and uses OLD behavior.  Use
> the cmake_policy command to set it to OLD or NEW explicitly.