### PR TITLE
Fix parseString ? and slight change to fixIndex

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -67,26 +67,18 @@ static inline bool isNewLine(const char c) {
 // Make index zero-base, and also support relative index. 
 static inline int fixIndex(int idx, int n)
 {
-  int i;
-
-  if (idx > 0) {
-    i = idx - 1;
-  } else if (idx == 0) {
-    i = 0;
-  } else { // negative value = relative
-    i = n + idx;
-  }
-  return i;
+  if (idx > 0) return idx - 1;
+  if (idx == 0) return 0;
+  return n + idx; // negative value = relative
 }
 
 static inline std::string parseString(const char*& token)
 {
   std::string s;
-  int b = strspn(token, " \t");
+  token += strspn(token, " \t");
   int e = strcspn(token, " \t\r");
-  s = std::string(&token[b], &token[e]);
-
-  token += (e - b);
+  s = std::string(&token, &token[e]);
+  token += e;
   return s;
 }
 

--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -77,7 +77,7 @@ static inline std::string parseString(const char*& token)
   std::string s;
   token += strspn(token, " \t");
   int e = strcspn(token, " \t\r");
-  s = std::string(&token, &token[e]);
+  s = std::string(token, &token[e]);
   token += e;
   return s;
 }


### PR DESCRIPTION
function parseString seemed to not increment token after it used strspn to get the length of the whitespace characters at the beginning of token. So strcspn called right after that would return 0 and the created string would be an empty string.

Seems to have been working so far since it gets passed strings that don't begin with whitespace characters.