### PR TITLE
Add support for referencing multiple mtllibs

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -406,7 +406,6 @@ static bool exportFaceGroupToShape(
 std::string LoadMtl(std::map<std::string, int> &material_map,
                     std::vector<material_t> &materials,
                     std::istream &inStream) {
-  material_map.clear();
   std::stringstream err;
 
   material_t material;


### PR DESCRIPTION
This extremely minor change allows tinyobjloader to handle OBJ files that reference multiple MTL files. I'm not sure if this is a very common thing to encounter but Wikipedia says it's legal to have multiple mtllibs and it's such a small tweak I thought I'd see if you thought it was worth supporting.