### PR TITLE
Add CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,18 +26,26 @@ add_library(tinyobjloader
 			${tinyobjloader-Source}
 	)
 
-add_executable(test_loader ${tinyobjloader-Test-Source})
-target_link_libraries(test_loader tinyobjloader)
+option(TINYOBJLOADER_BUILD_TEST_LOADER "Build Test Loader Application" OFF)
 
-add_executable(obj_sticher ${tinyobjloader-examples-objsticher})
-target_link_libraries(obj_sticher tinyobjloader)
+if(TINYOBJLOADER_BUILD_TEST_LOADER)
+  add_executable(test_loader ${tinyobjloader-Test-Source})
+  target_link_libraries(test_loader tinyobjloader)
+endif()
+
+option(TINYOBJLOADER_BUILD_OBJ_STICHER "Build OBJ Sticher Application" OFF)
+if (TINYOBJLOADER_BUILD_OBJ_STICHER)
+  add_executable(obj_sticher ${tinyobjloader-examples-objsticher})
+  target_link_libraries(obj_sticher tinyobjloader)
+
+  install ( TARGETS
+    obj_sticher
+    DESTINATION
+    bin
+    )
+endif()
 
 #Installation
-install ( TARGETS
-  obj_sticher
-  DESTINATION
-  bin
-  )
 install ( TARGETS
   tinyobjloader
   DESTINATION


### PR DESCRIPTION
Add CMake options to toggle the TestLoader application and OBJ Sticher application so that including the project has a smaller footprint