### PR TITLE
Fix groups being ignored if they have 'usemtl' just before 'g'

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -764,8 +764,10 @@ std::string LoadObj(std::vector<shape_t> &shapes,
       bool ret = exportFaceGroupToShape(shape, vertexCache, v, vn, vt,
                                         faceGroup, material, name, true);
       if (ret) {
-        faceGroup.clear();
+          shapes.push_back(shape);
       }
+      shape = shape_t();
+      faceGroup.clear();
 
       if (material_map.find(namebuf) != material_map.end()) {
         material = material_map[namebuf];


### PR DESCRIPTION
If you have several groups with a `usemtl` line preceding the group definition `g`, all such groups except the last one are ignored. This should fix it.

I think this doesn't introduce side-effects, but it'd be good to test by loading some sample .obj files.

Problematic example file shared privately by email.