### PR TITLE
fix sscanf_s buffer size type

### DIFF
--- a/tiny_obj_loader.cc
+++ b/tiny_obj_loader.cc
@@ -469,7 +469,7 @@ std::string LoadMtl(std::map<std::string, int> &material_map,
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
 #ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, _countof(namebuf));
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
 #endif
@@ -767,7 +767,7 @@ std::string LoadObj(std::vector<shape_t> &shapes,
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
 #ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, _countof(namebuf));
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
 #endif
@@ -796,7 +796,7 @@ std::string LoadObj(std::vector<shape_t> &shapes,
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
 #ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, _countof(namebuf));
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
 #endif
@@ -862,7 +862,7 @@ std::string LoadObj(std::vector<shape_t> &shapes,
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
 #ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, _countof(namebuf));
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
       sscanf(token, "%s", namebuf);
 #endif


### PR DESCRIPTION
Uses of `sscanf_s` give the following warnings in 64-bit builds:

    tiny_obj_loader.cc(471): warning C4477: 'sscanf_s' : format string '%s' requires an argument of type 'int', but variadic argument 2 has type 'unsigned __int64'
    tiny_obj_loader.cc(471): note: this argument is used as a buffer size

This was fixed by casting the uses of _countof(namebuf) to `unsigned`, since the MSDN documentation for `sscanf_s` specifies that "The size parameter is of type **unsigned**, not **size_t**." (https://msdn.microsoft.com/en-us/library/t6z7bya3.aspx) This fix silences the warnings.