### PR TITLE
Changes the value indicating non-existent index to 0. 

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -535,7 +535,7 @@ static vertex_index parseTriple(const char **token, int vsize, int vnsize,
 // Parse raw triples: i, i/j/k, i//k, i/j
 static vertex_index parseRawTriple(const char **token) {
   vertex_index vi(
-      static_cast<int>(0x80000000));  // 0x80000000 = -2147483648 = invalid
+      static_cast<int>(0));  // 0 is an invalid index in OBJ
 
   vi.v_idx = atoi((*token));
   (*token) += strcspn((*token), "/ \t\r");


### PR DESCRIPTION
OBJ indices are 1 (or -1) based, so 0 is an invalid value.
This is an API breaking change.