### PR TITLE
(Re-)expose attributes to Python

### DIFF
--- a/python/main.cpp
+++ b/python/main.cpp
@@ -172,6 +172,7 @@ static PyObject* pyLoadObj(PyObject* self, PyObject* args) {
 
   PyDict_SetItemString(rtndict, "shapes", pyshapes);
   PyDict_SetItemString(rtndict, "materials", pymaterials);
+  PyDict_SetItemString(rtndict, "attribs", attribobj);
 
   return rtndict;
 }


### PR DESCRIPTION
As of https://github.com/syoyo/tinyobjloader/commit/5eef2b0914316786ce820964495663d809c6bf88, vertex attributes appear to be inaccessible to Python; while `attribobj` is constructed to hold this data, this appears to be dead code, as no reference to `attribobj` is included in the return from `LoadObj`.

This patch simply adds the `attribobj` dictionary alongside `shapes` and `materials` in the returned object, with the name `attribs`.