### PR TITLE
Fixed error in getting material name in LoadObjWithCallback

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1805,7 +1805,6 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {
       if (readMatFn) {
         token += 7;
-        token += 7;
 
         std::vector<std::string> filenames;
         SplitString(std::string(token), ' ', filenames);


### PR DESCRIPTION
When I want use LoadObjWithCallback instead of LoadObj, I was getting error that material name not found. In body of this code I saw doubled line.