### PR TITLE
Add std namespace for pow, ldexp, sscanf function calls.

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -529,7 +529,7 @@ static bool tryParseDouble(const char *s, const char *s_end, double *result) {
 
       // NOTE: Don't use powf here, it will absolutely murder precision.
       mantissa += static_cast<int>(*curr - 0x30) *
-                  (read < lut_entries ? pow_lut[read] : pow(10.0, -read));
+                  (read < lut_entries ? pow_lut[read] : std::pow(10.0, -read));
       read++;
       curr++;
       end_not_reached = (curr != s_end);
@@ -571,7 +571,7 @@ static bool tryParseDouble(const char *s, const char *s_end, double *result) {
 assemble:
   *result =
       (sign == '+' ? 1 : -1) *
-      (exponent ? ldexp(mantissa * pow(5.0, exponent), exponent) : mantissa);
+      (exponent ? std::ldexp(mantissa * std::pow(5.0, exponent), exponent) : mantissa);
   return true;
 fail:
   return false;
@@ -1020,7 +1020,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
       material.name = namebuf;
       continue;
@@ -1522,7 +1522,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
 
       int newMaterialId = -1;
@@ -1642,7 +1642,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
       name = std::string(namebuf);
 
@@ -1657,7 +1657,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
       tag.name = std::string(namebuf);
 
@@ -1686,7 +1686,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
         sscanf_s(token, "%s", stringValueBuffer,
                  (unsigned)_countof(stringValueBuffer));
 #else
-        sscanf(token, "%s", stringValueBuffer);
+        std::sscanf(token, "%s", stringValueBuffer);
 #endif
         tag.stringValues[i] = stringValueBuffer;
         token += tag.stringValues[i].size() + 1;
@@ -1833,7 +1833,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
       sscanf_s(token, "%s", namebuf,
                static_cast<unsigned int>(_countof(namebuf)));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
 
       int newMaterialId = -1;
@@ -1947,7 +1947,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
       std::string object_name = std::string(namebuf);
 
@@ -1967,7 +1967,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      std::sscanf(token, "%s", namebuf);
 #endif
       tag.name = std::string(namebuf);
 
@@ -1996,7 +1996,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
         sscanf_s(token, "%s", stringValueBuffer,
                  (unsigned)_countof(stringValueBuffer));
 #else
-        sscanf(token, "%s", stringValueBuffer);
+        std::sscanf(token, "%s", stringValueBuffer);
 #endif
         tag.stringValues[i] = stringValueBuffer;
         token += tag.stringValues[i].size() + 1;


### PR DESCRIPTION
Currently tinyobjloader does not compile on QNX system, the reason is that cxxx headers are used instead of xxx.h. As it turns out, C++ standard does not guarantee that after inclusion of the cxxx header the functions it contain will be injected into global namespace [[1] see appendix D.5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf#appendix.D) [[2]](http://www.qnx.com/developers/docs/660/index.jsp?topic=%2Fcom.qnx.doc.dinkum%2Ftopic%2Fcpp11%2Findex.html) [[3]](https://developers.redhat.com/blog/2016/02/29/why-cstdlib-is-more-complicated-than-you-might-think/).

My change adds std:: before each call of the functions from cmath and sscanf. I have issues with only these ones. With this patch applied tinyobjloader compiles for me.

Maybe maintainers may think of making this library more portable by implementing one of the next long-term solutions: 
- switch to xxx.h headers instead of cxxx.
- prefix all standard C function calls with std namespace (I can see that standard library functions are used heavily, so I have not gone through prefixing all of them before there is an agreement with maintainers).

I can implement any of these.
 
[1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf#appendix.D
[2] http://www.qnx.com/developers/docs/660/index.jsp?topic=%2Fcom.qnx.doc.dinkum%2Ftopic%2Fcpp11%2Findex.html
[3] https://developers.redhat.com/blog/2016/02/29/why-cstdlib-is-more-complicated-than-you-might-think/
@sschuberth