### PR TITLE
Fix Cppcheck warnings

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1032,11 +1032,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
       // set new mtl name
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
       material.name = namebuf;
       continue;
     }
@@ -1543,11 +1539,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
 
       int newMaterialId = -1;
       if (material_map.find(namebuf) != material_map.end()) {
@@ -1663,11 +1655,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       // @todo { multiple object name? }
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
       name = std::string(namebuf);
 
       continue;
@@ -1678,11 +1666,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
       tag.name = std::string(namebuf);
 
       token += tag.name.size() + 1;
@@ -1706,12 +1690,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
         char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
 
-#ifdef _MSC_VER
-        sscanf_s(token, "%s", stringValueBuffer,
-                 (unsigned)_countof(stringValueBuffer));
-#else
-        std::sscanf(token, "%s", stringValueBuffer);
-#endif
+        std::snprintf(stringValueBuffer, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
         tag.stringValues[i] = stringValueBuffer;
         token += tag.stringValues[i].size() + 1;
       }
@@ -1853,12 +1832,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf,
-               static_cast<unsigned int>(_countof(namebuf)));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
 
       int newMaterialId = -1;
       if (material_map.find(namebuf) != material_map.end()) {
@@ -1968,11 +1942,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
       // @todo { multiple object name? }
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
       std::string object_name = std::string(namebuf);
 
       if (callback.object_cb) {
@@ -1988,11 +1958,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 
       char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-#ifdef _MSC_VER
-      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
-#else
-      std::sscanf(token, "%s", namebuf);
-#endif
+      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
       tag.name = std::string(namebuf);
 
       token += tag.name.size() + 1;
@@ -2016,12 +1982,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
         char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
 
-#ifdef _MSC_VER
-        sscanf_s(token, "%s", stringValueBuffer,
-                 (unsigned)_countof(stringValueBuffer));
-#else
-        std::sscanf(token, "%s", stringValueBuffer);
-#endif
+        std::snprintf(stringValueBuffer, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
         tag.stringValues[i] = stringValueBuffer;
         token += tag.stringValues[i].size() + 1;
       }

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #define TINY_OBJ_LOADER_H_
 
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -364,7 +365,6 @@ namespace tinyobj {
 
 MaterialReader::~MaterialReader() {}
 
-#define TINYOBJ_SSCANF_BUFFER_SIZE (4096)
 
 struct vertex_index {
   int v_idx, vt_idx, vn_idx;
@@ -1030,10 +1030,10 @@ void LoadMtl(std::map<std::string, int> *material_map,
       has_tr = false;
 
       // set new mtl name
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-      material.name = namebuf;
+      std::stringstream ss;
+      ss << token;
+      material.name = ss.str();
       continue;
     }
 
@@ -1537,9 +1537,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
     // use mtl
     if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
+      std::stringstream ss;
+      ss << token;
+      std::string namebuf = ss.str();
 
       int newMaterialId = -1;
       if (material_map.find(namebuf) != material_map.end()) {
@@ -1653,10 +1654,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       shape = shape_t();
 
       // @todo { multiple object name? }
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-      name = std::string(namebuf);
+      std::stringstream ss;
+      ss << token;
+      name = ss.str();
 
       continue;
     }
@@ -1664,10 +1665,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if (token[0] == 't' && IS_SPACE(token[1])) {
       tag_t tag;
 
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-      tag.name = std::string(namebuf);
+      std::stringstream ss;
+      ss << token;
+      tag.name = ss.str();
 
       token += tag.name.size() + 1;
 
@@ -1688,10 +1689,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
-        char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
-
-        std::snprintf(stringValueBuffer, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-        tag.stringValues[i] = stringValueBuffer;
+        std::stringstream ss;
+        ss << token;
+        tag.stringValues[i] = ss.str();
         token += tag.stringValues[i].size() + 1;
       }
 
@@ -1830,9 +1830,10 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 
     // use mtl
     if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 7;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
+      std::stringstream ss;
+      ss << token;
+      std::string namebuf = ss.str();
 
       int newMaterialId = -1;
       if (material_map.find(namebuf) != material_map.end()) {
@@ -1846,7 +1847,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
       }
 
       if (callback.usemtl_cb) {
-        callback.usemtl_cb(user_data, namebuf, material_id);
+        callback.usemtl_cb(user_data, namebuf.c_str(), material_id);
       }
 
       continue;
@@ -1940,10 +1941,11 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     // object name
     if (token[0] == 'o' && IS_SPACE((token[1]))) {
       // @todo { multiple object name? }
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-      std::string object_name = std::string(namebuf);
+
+      std::stringstream ss;
+      ss << token;
+      std::string object_name = ss.str();
 
       if (callback.object_cb) {
         callback.object_cb(user_data, object_name.c_str());
@@ -1956,10 +1958,10 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     if (token[0] == 't' && IS_SPACE(token[1])) {
       tag_t tag;
 
-      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
-      std::snprintf(namebuf, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-      tag.name = std::string(namebuf);
+      std::stringstream ss;
+      ss << token;
+      tag.name = ss.str();
 
       token += tag.name.size() + 1;
 
@@ -1980,10 +1982,9 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 
       tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
-        char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
-
-        std::snprintf(stringValueBuffer, TINYOBJ_SSCANF_BUFFER_SIZE, "%s", token);
-        tag.stringValues[i] = stringValueBuffer;
+        std::stringstream ss;
+        ss << token;
+        tag.stringValues[i] = ss.str();
         token += tag.stringValues[i].size() + 1;
       }
 

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1676,7 +1676,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     if (token[0] == 't' && IS_SPACE(token[1])) {
       tag_t tag;
 
-      char namebuf[4096];
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
@@ -1704,7 +1704,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
       tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
-        char stringValueBuffer[4096];
+        char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
 
 #ifdef _MSC_VER
         sscanf_s(token, "%s", stringValueBuffer,
@@ -1986,7 +1986,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
     if (token[0] == 't' && IS_SPACE(token[1])) {
       tag_t tag;
 
-      char namebuf[4096];
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
       token += 2;
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
@@ -2014,7 +2014,7 @@ bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
 
       tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
       for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
-        char stringValueBuffer[4096];
+        char stringValueBuffer[TINYOBJ_SSCANF_BUFFER_SIZE];
 
 #ifdef _MSC_VER
         sscanf_s(token, "%s", stringValueBuffer,

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -44,7 +44,6 @@ THE SOFTWARE.
 #define TINY_OBJ_LOADER_H_
 
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -401,20 +401,22 @@ static std::istream &safeGetline(std::istream &is, std::string &t) {
   std::istream::sentry se(is, true);
   std::streambuf *sb = is.rdbuf();
 
-  for (;;) {
-    int c = sb->sbumpc();
-    switch (c) {
-      case '\n':
-        return is;
-      case '\r':
-        if (sb->sgetc() == '\n') sb->sbumpc();
-        return is;
-      case EOF:
-        // Also handle the case when the last line has no line ending
-        if (t.empty()) is.setstate(std::ios::eofbit);
-        return is;
-      default:
-        t += static_cast<char>(c);
+  if (se) {
+    for (;;) {
+      int c = sb->sbumpc();
+      switch (c) {
+        case '\n':
+          return is;
+        case '\r':
+          if (sb->sgetc() == '\n') sb->sbumpc();
+          return is;
+        case EOF:
+          // Also handle the case when the last line has no line ending
+          if (t.empty()) is.setstate(std::ios::eofbit);
+          return is;
+        default:
+          t += static_cast<char>(c);
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request fixes a few [Cppcheck](http://cppcheck.sourceforge.net/) warnings.

* `Variable 'se' is assigned a value that is never used.`
    * Fixed by calling `operator bool()` on the sentry instance before using it.
* `scanf without field width limits can crash with huge input data.`
    * Fixed by replacing `sscanf` with ~~`std::snprintf`~~ `std::stringstream`

~~This also replaces a couple uses of `4096` with `TINYOBJ_SSCANF_BUFFER_SIZE` where it looks appropriate.~~ This deletes the macro `TINYOBJ_SSCANF_BUFFER_SIZE`. I've run `make check` and all tests pass.