### PR TITLE
remove the keyword `register' for C++17

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -659,7 +659,7 @@ static bool exportFaceGroupToShape(
     const size_t nIndexs = shape.mesh.indices.size();
     if (nIndexs % 3 == 0) {
       shape.mesh.normals.resize(shape.mesh.positions.size());
-      for (register size_t iIndices = 0; iIndices < nIndexs; iIndices += 3) {
+      for (size_t iIndices = 0; iIndices < nIndexs; iIndices += 3) {
         float3 v1, v2, v3;
         memcpy(&v1, &shape.mesh.positions[shape.mesh.indices[iIndices] * 3],
                sizeof(float3));


### PR DESCRIPTION
WE should remove the keyword `register' since it is no longer supported in C++17.