### PR TITLE
Bugfix for multiple texture

### DIFF
--- a/experimental/tinyobj_loader_opt.h
+++ b/experimental/tinyobj_loader_opt.h
@@ -1440,7 +1440,9 @@ bool parseObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     // std::cout << "mtllib :" << material_filename << std::endl;
 
     auto t1 = std::chrono::high_resolution_clock::now();
-
+	if (material_filename.back() == '\r') {
+			material_filename.pop_back();
+	}
     std::ifstream ifs(material_filename);
     if (ifs.good()) {
       LoadMtl(&material_map, materials, &ifs);


### PR DESCRIPTION
1. sometimes '\r' would appear in material file name which will lead to failure file finding
2. bugfix for obj file with multiple textures
 -problem occurs when multiple texture material is defined in one obj, where material_id could not be read correctly. This is caused by 
 (1) material_id is accessible among threads
 (2) in one thread, material_id would stay -1 until a  use material command is encountered. 
So a check and fix for the material_id  is necessary after multithread merge
 