### PR TITLE
Adapt the v1.0.x data format to the WriteObj function

### DIFF
--- a/examples/obj_sticher/obj_writer.h
+++ b/examples/obj_sticher/obj_writer.h
@@ -1,7 +1,7 @@
 #ifndef __OBJ_WRITER_H__
 #define __OBJ_WRITER_H__
 
-#include "tiny_obj_loader.h"
+#include "../../tiny_obj_loader.h"
 
 extern bool WriteObj(const std::string& filename, const tinyobj::attrib_t& attributes, const std::vector<tinyobj::shape_t>& shapes, const std::vector<tinyobj::material_t>& materials, bool coordTransform = false);
 

--- a/examples/obj_sticher/obj_writer.h
+++ b/examples/obj_sticher/obj_writer.h
@@ -1,9 +1,8 @@
 #ifndef __OBJ_WRITER_H__
 #define __OBJ_WRITER_H__
 
-#include "../../tiny_obj_loader.h"
+#include "tiny_obj_loader.h"
 
-extern bool WriteObj(const std::string& filename, const std::vector<tinyobj::shape_t>& shapes, const std::vector<tinyobj::material_t>& materials, bool coordTransform = false);
-
+extern bool WriteObj(const std::string& filename, const tinyobj::attrib_t& attributes, const std::vector<tinyobj::shape_t>& shapes, const std::vector<tinyobj::material_t>& materials, bool coordTransform = false);
 
 #endif // __OBJ_WRITER_H__


### PR DESCRIPTION
Changes:
- Changed signature (added attributes parameter) of WriteObj(...)
- Added the illum keyword to material file output
- Changed obj output style to the following format:
mtllib ...
[list-of-vertices]
[list-of-normals]
[list-of-texture-coords]
[groups-of-face-indices]

In this apporach I am assuming each shape/group either has vertex-normals (resp. texture-coords), or it doesn't, i.e. if one vertex has a normal, every other vertex within the same shape is assumed to have a normal as well.
Shifting the check for vertex normals (line 111) and texture-coords (line 112) into the per-face-loop (line 117) may be more precise, but also will reduce performance. Since I didn't see any example of faces within one group having different attributes yet, I left the check outside the loop.

To debug the obj files, I added some newlines and left them, since they are not adding too much space to the result, but make a huge difference in terms of human readability.