### PR TITLE
Ensure mtl_basedir ends with a directory separator

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1155,7 +1155,7 @@ static bool exportFaceGroupToShape(shape_t *shape,
             // ???
             continue;
           }
-          
+
           size_t ovi = size_t(
               remainingFace.vertex_indices[idx]
                   .v_idx);
@@ -1739,6 +1739,13 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
   std::string baseDir;
   if (mtl_basedir) {
     baseDir = mtl_basedir;
+#ifndef _WIN32
+    const char dirsep = '/';
+#else
+    const char dirsep = '\\';
+#endif
+    if (baseDir[baseDir.length() - 1] != dirsep)
+      baseDir += dirsep;
   }
   MaterialFileReader matFileReader(baseDir);
 


### PR DESCRIPTION
Currently, if `mtl_basedir` doesn't end with a separator character (`/` on *nix or `\\` on Windows) the loader will neither raise any warning nor correctly load the materials. 
With this commit, `LoadObj` will automatically insert a separator at the end of the basedir if needed.