### PR TITLE
Added support for line paths.

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1043,11 +1043,10 @@ static bool exportGroupsToShape(shape_t *shape,
 
     size_t npolys = face.vertex_indices.size();
 
-    /*
     if (npolys < 3) {
       // Face must have 3+ vertices.
       continue;
-    }*/
+    }
 
     vertex_index_t i0 = face.vertex_indices[0];
     vertex_index_t i1(-1);

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1027,7 +1027,7 @@ static int pnpoly(int nvert, T *vertx, T *verty, T testx,
 // TODO(syoyo): refactor function.
 static bool exportGroupsToShape(shape_t *shape,
                                    const std::vector<face_t> &faceGroup,
-                                   const std::vector<int> &lineGroup,
+                                   std::vector<int> &lineGroup,
                                    const std::vector<tag_t> &tags,
                                    const int material_id,
                                    const std::string &name, bool triangulate,

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1035,6 +1035,10 @@ static bool exportGroupsToShape(shape_t *shape,
 
 
 
+  if (faceGroup.empty() && lineGroup.empty()) {
+    return false;
+  }
+
   if (!faceGroup.empty()) {
 
   // Flatten vertices and indices

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1270,7 +1270,7 @@ static bool exportGroupsToShape(shape_t *shape,
 
 
   if(!lineGroup.empty()){
-      shape->path.indices = std::move(lineGroup);
+      shape->path.indices.swap(lineGroup);
   }
 
   return true;

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1937,7 +1937,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       if (newMaterialId != material) {
         // Create per-face material. Thus we don't add `shape` to `shapes` at
         // this time.
-        // just clear `faceGroup` after `exportFaceGroupToShape()` call.
+        // just clear `faceGroup` after `exportGroupsToShape()` call.
         exportGroupsToShape(&shape, faceGroup, lineGroup, tags, material, name,
                                triangulate, v);
         faceGroup.clear();
@@ -2140,7 +2140,7 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
 
   bool ret = exportGroupsToShape(&shape, faceGroup, lineGroup, tags, material, name,
                                     triangulate, v);
-  // exportFaceGroupToShape return false when `usemtl` is called in the last
+  // exportGroupsToShape return false when `usemtl` is called in the last
   // line.
   // we also add `shape` to `shapes` when `shape.mesh` has already some
   // faces(indices)

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2149,12 +2149,6 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
   }
   faceGroup.clear();  // for safety
 
-
-        for(int i=0;i<lineGroup.size();i++){
-            //printf("facegroup indices size: %i\n", faceGroup[i].vertex_indices.size());
-            printf("linegroup[%i]: %i\n", i, lineGroup[i]);
-        }
-
   if (err) {
     (*err) += errss.str();
   }


### PR DESCRIPTION
I needed to be able to import lines from an obj file I exported from blender and was disappointed to see it wasn't supported, so I added support; support for the 'l' character, similar to 'f' character. For more information check wikipedia: https://en.wikipedia.org/wiki/Wavefront_.obj_file#Line_elements

If there are any problems that I could fix than just say so. I hope this is of use to someone else. Thanks!