### PR TITLE
Produce an error and return when indices and data dont match.

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2161,9 +2161,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     // Ignore unknown command.
   }
 
-  if (greatest_vertex_index >= v.size()
-    || greatest_normal_index >= vn.size()
-    || greatest_texcoord_index >= vt.size())
+  if (greatest_vertex_index * 3 >= int(v.size())
+    || greatest_normal_index * 3 >= int(vn.size())
+    || greatest_texcoord_index * 2 >= int(vt.size()))
   {
     if (err) {
       std::stringstream ss;

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1789,6 +1789,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
   unsigned int current_smoothing_id =
       0;  // Initial value. 0 means no smoothing.
 
+  int greatest_vertex_index = -1;
+  int greatest_normal_index = -1;
+  int greatest_texcoord_index = -1;
+
   shape_t shape;
 
   size_t line_num = 0;
@@ -1906,6 +1910,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
           }
           return false;
         }
+
+        greatest_vertex_index = std::max(greatest_vertex_index, vi.v_idx);
+        greatest_normal_index = std::max(greatest_normal_index, vi.vn_idx);
+        greatest_texcoord_index = std::max(greatest_texcoord_index, vi.vt_idx);
 
         face.vertex_indices.push_back(vi);
         size_t n = strspn(token, " \t\r");
@@ -2151,6 +2159,18 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     }  // smoothing group id
 
     // Ignore unknown command.
+  }
+
+  if (greatest_vertex_index >= v.size()
+    || greatest_normal_index >= vn.size()
+    || greatest_texcoord_index >= vt.size())
+  {
+    if (err) {
+      std::stringstream ss;
+      ss << "WARN: Indices do not match the data.\n" << std::endl;
+      (*err) += ss.str();
+    }
+    return false;
   }
 
   bool ret = exportGroupsToShape(&shape, faceGroup, lineGroup, tags, material,

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2161,16 +2161,29 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     // Ignore unknown command.
   }
 
-  if (greatest_v_idx * 3 >= int(v.size())
-    || greatest_vn_idx * 3 >= int(vn.size())
-    || greatest_vt_idx * 2 >= int(vt.size()))
+  if (greatest_v_idx >= static_cast<int>(v.size() / 3))
   {
     if (err) {
       std::stringstream ss;
-      ss << "WARN: Indices do not match the data.\n" << std::endl;
+      ss << "WARN: Vertex indices out of bounds.\n" << std::endl;
       (*err) += ss.str();
     }
-    return false;
+  }
+  if (greatest_vn_idx >= static_cast<int>(vn.size() / 3))
+  {
+    if (err) {
+      std::stringstream ss;
+      ss << "WARN: Vertex normal indices out of bounds.\n" << std::endl;
+      (*err) += ss.str();
+    }
+  }
+  if (greatest_vt_idx >= static_cast<int>(vt.size() / 2))
+  {
+    if (err) {
+      std::stringstream ss;
+      ss << "WARN: Vertex texcoord indices out of bounds.\n" << std::endl;
+      (*err) += ss.str();
+    }
   }
 
   bool ret = exportGroupsToShape(&shape, faceGroup, lineGroup, tags, material,

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1789,9 +1789,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
   unsigned int current_smoothing_id =
       0;  // Initial value. 0 means no smoothing.
 
-  int greatest_vertex_index = -1;
-  int greatest_normal_index = -1;
-  int greatest_texcoord_index = -1;
+  int greatest_v_idx = -1;
+  int greatest_vn_idx = -1;
+  int greatest_vt_idx = -1;
 
   shape_t shape;
 
@@ -1911,9 +1911,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
           return false;
         }
 
-        greatest_vertex_index = std::max(greatest_vertex_index, vi.v_idx);
-        greatest_normal_index = std::max(greatest_normal_index, vi.vn_idx);
-        greatest_texcoord_index = std::max(greatest_texcoord_index, vi.vt_idx);
+        greatest_v_idx = greatest_v_idx > vi.v_idx ? greatest_v_idx : vi.v_idx;
+        greatest_vn_idx = greatest_vn_idx > vi.vn_idx ? greatest_vn_idx : vi.vn_idx;
+        greatest_vt_idx = greatest_vt_idx > vi.vt_idx ? greatest_vt_idx : vi.vt_idx;
 
         face.vertex_indices.push_back(vi);
         size_t n = strspn(token, " \t\r");
@@ -2161,9 +2161,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
     // Ignore unknown command.
   }
 
-  if (greatest_vertex_index * 3 >= int(v.size())
-    || greatest_normal_index * 3 >= int(vn.size())
-    || greatest_texcoord_index * 2 >= int(vt.size()))
+  if (greatest_v_idx * 3 >= int(v.size())
+    || greatest_vn_idx * 3 >= int(vn.size())
+    || greatest_vt_idx * 2 >= int(vt.size()))
   {
     if (err) {
       std::stringstream ss;


### PR DESCRIPTION
A malformed obj file can have missing data but still have face indices.
This PR handles such a case by reporting an error and returning with a failed status.