### PR TITLE
tiny_obj_loader.h: initialize pad_ in constructor

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -435,7 +435,7 @@ struct face_t {
   int pad_;
   std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
 
-  face_t() : smoothing_group_id(0) {}
+  face_t() : pad_(0), smoothing_group_id(0) {}
 };
 
 struct line_t {

--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -435,7 +435,7 @@ struct face_t {
   int pad_;
   std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
 
-  face_t() : pad_(0), smoothing_group_id(0) {}
+  face_t() : smoothing_group_id(0), pad_(0) {}
 };
 
 struct line_t {


### PR DESCRIPTION
cppcheck complains about the `pad_` variable being uninitialized in the constructor:

~~~
[tiny_obj_loader.h:438]: (warning) Member variable 'face_t::pad_' is not initialized in the constructor.
~~~