### PR TITLE
namespace for cmake export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ install(TARGETS
   )
 install(EXPORT
   ${PROJECT_NAME}-targets
+  NAMESPACE
+  tinyobjloader::
   DESTINATION
   ${TINYOBJLOADER_CMAKE_DIR}
   )


### PR DESCRIPTION
Adding namespace for cmake export is becoming the standard, here are some reasons:

1. With namespace targets like Foo::Foo, if it's missing the config will give you an error rather than just silently adding -lFoo

2. The namespace is a nice way to tell when a library is imported vs part of the project, as most people do follow that standard for imported targets.

However, this is a non backwards compatible change, after this change, the way to link to tinyobjloader in cmake for the downstream will become

`target_link_libraries(${PROJECT_NAME} tinyobjloader::tinyobjloader)`