### PR TITLE
Fixed gitmodules location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pybind11/tools/clang"]
+	path = pybind11/tools/clang
+	url = ../../wjakob/clang-cindex-python3

--- a/pybind11/.gitmodules
+++ b/pybind11/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/clang"]
-	path = tools/clang
-	url = ../../wjakob/clang-cindex-python3


### PR DESCRIPTION
Fixed gitmodules location according to https://git-scm.com/docs/gitmodules . This fixes Cmake's cloning error due to git failing to clone submodule.

Another way to fix this is to make pybind11 a git submodule so Cmake can recursively clone it.