### PR TITLE
Add numpy_indices method

### DIFF
--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -1,6 +1,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "pybind11/numpy.h"
+#include <cstring>
 
 // Use double precision for better python integration.
 #define TINYOBJLOADER_USE_DOUBLE
@@ -114,7 +115,13 @@ PYBIND11_MODULE(tinyobjloader, tobj_module)
 
   py::class_<mesh_t>(tobj_module, "mesh_t")
     .def(py::init<>())
-    .def_readonly("indices", &mesh_t::indices);
+    .def_readonly("indices", &mesh_t::indices)
+    .def("numpy_indices", [] (mesh_t &instance) {
+        auto ret = py::array_t<int>(instance.indices.size() * 3);
+        py::buffer_info buf = ret.request();
+        memcpy(buf.ptr, instance.indices.data(), instance.indices.size() * 3 * sizeof(int));
+        return ret;
+    });
 
   py::class_<lines_t>(tobj_module, "lines_t")
     .def(py::init<>());


### PR DESCRIPTION
The original indices member is not python friendly
```python
    for shape in reader.GetShapes():
        for idx in shape.mesh.indices:
            vid.append(idx.vertex_index)
```

so I added a new method numpy_indices
```python
    # stack all the indices together
    for shape in reader.GetShapes():
        indices = shape.mesh.numpy_indices().reshape(-1, 3, 3)
        # indices[..., 0] for referencing the vertex indices
        vid.append(indices[..., 0])
        nid.append(indices[..., 1])
        tid.append(indices[..., 2])

    print(np.concatenate(vid))
```
