### PR TITLE
Fix for issue syoyo/tinyobjloader#217

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${LIBRARY_NAME} ${tinyobjloader-Source})
 if(BUILD_SHARED_LIBS)
   set_target_properties(${LIBRARY_NAME} PROPERTIES
     SOVERSION ${TINYOBJLOADER_SOVERSION}
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
   )
 endif()
 


### PR DESCRIPTION
Set a target property WINDOWS_EXPORT_ALL_SYMBOLS to true every time shared libraries are built.

This enables the generation of symbols to be exported in Windows DLLs.