### PR TITLE
Document conan package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Old version is available as `v0.9.x` branch https://github.com/syoyo/tinyobjload
 * 14 Apr, 2019 : Bump version v2.0.0 rc0. New C++ API and python bindings!(1.x API still exists for backward compatibility)
 * 20 Aug, 2016 : Bump version v1.0.0. New data structure and API!
 
-## Requirents
+## Requirements
 
 * C++03 compiler
 
 ### Old version
 
-Previous old version is avaiable in `v0.9.x` branch.
+Previous old version is available in `v0.9.x` branch.
 
 ## Example
 
@@ -132,7 +132,7 @@ TinyObjLoader is successfully used in ...
 
 TinyObjLoader is licensed under MIT license.
 
-### Third party licences.
+### Third party licenses.
 
 * pybind11 : BSD-style license.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/syoyo/tinyobjloader/badge.svg?branch=master)](https://coveralls.io/github/syoyo/tinyobjloader?branch=master)
 
+[![Download](https://api.bintray.com/packages/conan/conan-center/tinyobjloader%3A_/images/download.svg)](https://bintray.com/conan/conan-center/tinyobjloader%3A_/_latestVersion)
+
 [https://github.com/syoyo/tinyobjloader](https://github.com/syoyo/tinyobjloader)
 
 Tiny but powerful single file wavefront obj loader written in C++03. No dependency except for C++ STL. It can parse over 10M polygons with moderate memory and time.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ TinyObjLoader is licensed under MIT license.
 
 ## Usage
 
+### Installation
+
+One option is to simply copy the header file into your project and to make sure that `TINYOBJLOADER_IMPLEMENTATION` is defined exactly once.
+
+Tinyobjlaoder is also available as a [conan package](https://bintray.com/conan/conan-center/tinyobjloader%3A_/_latestVersion). Conan integrates with many build systems and lets you avoid manual dependency installation. Their [documentation](https://docs.conan.io/en/latest/getting_started.html) is a great starting point.
+
 ### Data format
 
 `attrib_t` contains single and linear array of vertex data(position, normal and texcoord).


### PR DESCRIPTION
Tinyobjloader is now live on [conan-center](https://bintray.com/conan/conan-center/tinyobjloader%3A_/_latestVersion).

This pull request documents the package as an installation option and adds the appropriate badge.

Fixes #206 