### PR TITLE
correspond to 3 digit smoothing group index

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2522,10 +2522,9 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
         continue;
       }
 
-      if (strlen(token) >= 3) {
-        if (token[0] == 'o' && token[1] == 'f' && token[2] == 'f') {
-          current_smoothing_id = 0;
-        }
+      if (strlen(token) >= 3 && token[0] == 'o' && token[1] == 'f' &&
+          token[2] == 'f') {
+        current_smoothing_id = 0;
       } else {
         // assume number
         int smGroupId = parseInt(&token);


### PR DESCRIPTION
Hi,I wanted to load a lot of smoothing groups, but tinyobjloader couldn't load 100 or more smoothing group ids.
So I fixed it.