### PR TITLE
fix cmake downstream find_package failure in double mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ install(FILES
   ${TINYOBJLOADER_DOC_DIR}
   )
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_NAME}-config.cmake"
-  "${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_NAME}-config-version.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
   DESTINATION
   ${TINYOBJLOADER_CMAKE_DIR}
   )


### PR DESCRIPTION
Without this PR, when the downstream CMakeLists uses `find_package(tinyobjloader REQUIRED)`, there will be the below error:

```
CMake Error at modules/Mesh/CMakeLists.txt:68 (find_package):
  By not providing "Findtinyobjloader.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "tinyobjloader", but CMake did not find one.

  Could not find a package configuration file provided by "tinyobjloader"
  with any of the following names:

    tinyobjloaderConfig.cmake
    tinyobjloader-config.cmake

  Add the installation prefix of "tinyobjloader" to CMAKE_PREFIX_PATH or set
  "tinyobjloader_DIR" to a directory containing one of the above files.  If
  "tinyobjloader" provides a separate development package or SDK, be sure it
  has been installed.
```

The reason is the tinyobjloader config file path `/usr/lib/x86_64-linux-gnu/tinyobjloader/cmake/tinyobjloader_double-config.cmake` does not conform to one of the cmake default path in module mode, after this change it will be back to `/usr/lib/x86_64-linux-gnu/tinyobjloader/cmake/tinyobjloader-config.cmake`, which is one of the cmake default path in module mode, so the downstream CMakeLists can use `find_package(tinyobjloader REQUIRED)` and `target_link_libraries(${PROJECT_NAME} tinyobjloader::tinyobjloader_double)` like usual.