### PR TITLE
Python bindings: Expose additional fields

### DIFF
--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -38,6 +38,12 @@ PYBIND11_MODULE(tinyobjloader, tobj_module)
   py::class_<attrib_t>(tobj_module, "attrib_t")
     .def(py::init<>())
     .def_readonly("vertices", &attrib_t::vertices)
+    .def("numpy_vertices", [] (attrib_t &instance) {
+        auto ret = py::array_t<real_t>(instance.vertices.size());
+        py::buffer_info buf = ret.request();
+        memcpy(buf.ptr, instance.vertices.data(), instance.vertices.size() * sizeof(real_t));
+        return ret;
+    })
     .def_readonly("normals", &attrib_t::normals)
     .def_readonly("texcoords", &attrib_t::texcoords)
     .def_readonly("colors", &attrib_t::colors)
@@ -115,6 +121,13 @@ PYBIND11_MODULE(tinyobjloader, tobj_module)
 
   py::class_<mesh_t>(tobj_module, "mesh_t")
     .def(py::init<>())
+    .def_readonly("num_face_vertices", &mesh_t::num_face_vertices)
+    .def("numpy_num_face_vertices", [] (mesh_t &instance) {
+        auto ret = py::array_t<unsigned char>(instance.num_face_vertices.size());
+        py::buffer_info buf = ret.request();
+        memcpy(buf.ptr, instance.num_face_vertices.data(), instance.num_face_vertices.size() * sizeof(unsigned char));
+        return ret;
+    })
     .def_readonly("indices", &mesh_t::indices)
     .def("numpy_indices", [] (mesh_t &instance) {
         auto ret = py::array_t<int>(instance.indices.size() * 3);


### PR DESCRIPTION
The `num_face_vertices` property is essential for interpreting `mesh_t.numpy_indices()`, and the `numpy_vertices()` function improves performance when pulling vertices.