### PR TITLE
Fix: Some data may be ignored when loading objects from .obj

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -2438,7 +2438,10 @@ bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
       // flush previous face group.
       bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
                                      triangulate, v);
-      if (ret) {
+      (void)ret;  // return value not used.
+
+      if (shape.mesh.indices.size() > 0 || shape.lines.indices.size() > 0 ||
+          shape.points.indices.size() > 0) {
         shapes->push_back(shape);
       }
 


### PR DESCRIPTION
It seems like the current version of the loader has a bug, because of which some objects may be skipped while loading an .obj file.

See the following .obj example:
```
mtllib test.mtl

v -1.000000 1.202466 1.000000
v 1.000000 1.202466 1.000000
v -1.000000 1.202466 -1.000000
v 1.000000 1.202466 -1.000000
vn 0.0000 1.0000 0.0000
v -1.000000 0.000000 1.000000
v 1.000000 0.000000 1.000000
v -1.000000 0.000000 -1.000000
v 1.000000 0.000000 -1.000000
vn 0.0000 1.0000 0.0000

usemtl None
o Plane.001
f 1//1 2//1 4//1

usemtl None1
o Plane
f 5//2 6//2 8//2
```

When the loader encounters the first object group, `o Plane.001`, it collects the face from the next line properly to the `prim_group` (line 2301). Then, the `usemtl` follows, and because the material is changed, the current `prim_group` is written to the current `shape` via the call to `exportGroupsToShape` at line 2324.

After that, a new object, `o Plane` is encountered, and the `exportGroupsToShape` is called again, now at line 2439. But this time the `prim_group` is already empty since it was dumped to the `shape` already. Because of that, `exportGroupsToShape` returns `false`. And the next `if (ret)` check ignores the fact that there's some data in the `shape` already, and skips adding the `shape` to the `shapes` collection. This way, the data which was already parsed and stored in the current shape is simply ignored.

I propose to do the same as it is already in the code processing groups: ignore the return value of the last `exportGroupsToShape` call, and check the `shape` content instead to decide whether to add it to the `shapes` or not.