### PR TITLE
Set a decent diffuse value when map_Kd is present and Kd is not

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1669,6 +1669,10 @@ void LoadMtl(std::map<std::string, int> *material_map,
   bool has_d = false;
   bool has_tr = false;
 
+  // has_kd is used to set a default diffuse value when map_Kd is present
+  // and Kd is not.
+  bool has_kd = false;
+
   std::stringstream warn_ss;
 
   size_t line_no = 0;
@@ -1750,6 +1754,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
       material.diffuse[0] = r;
       material.diffuse[1] = g;
       material.diffuse[2] = b;
+      has_kd = true;
       continue;
     }
 
@@ -1902,6 +1907,16 @@ void LoadMtl(std::map<std::string, int> *material_map,
       token += 7;
       ParseTextureNameAndOption(&(material.diffuse_texname),
                                 &(material.diffuse_texopt), token);
+
+      // Set a decent diffuse default value if a diffuse texture is specified
+      // without a matching Kd value.
+      if (!has_kd)
+      {
+        material.diffuse[0] = 0.6;
+        material.diffuse[1] = 0.6;
+        material.diffuse[2] = 0.6;
+      }
+
       continue;
     }
 


### PR DESCRIPTION
This pull request addresses the situation where a MTL file has a `map_Kd` and no `Kd`. In this situation the default diffuse value of 0,0,0 is used. The problem is that this results in a black material.

Other programs, such as blender, use a higher default diffuse value. I believe blender uses 0.6, which I also use here.