### PR TITLE
Fix windows compiler warnings

### DIFF
--- a/tiny_obj_loader.h
+++ b/tiny_obj_loader.h
@@ -1912,9 +1912,9 @@ void LoadMtl(std::map<std::string, int> *material_map,
       // without a matching Kd value.
       if (!has_kd)
       {
-        material.diffuse[0] = 0.6;
-        material.diffuse[1] = 0.6;
-        material.diffuse[2] = 0.6;
+        material.diffuse[0] = static_cast<real_t>(0.6);
+        material.diffuse[1] = static_cast<real_t>(0.6);
+        material.diffuse[2] = static_cast<real_t>(0.6);
       }
 
       continue;


### PR DESCRIPTION
My previous [pull request](https://github.com/syoyo/tinyobjloader/pull/249) resulted in compiler warnings on Windows.  The warnings were:

```
tiny_obj_loader.h
'=': truncation from 'double' to 'tinyobj::real_t'
```

This PR fixes those compiler warnings.