### PR TITLE
Bump cibuildwheel to 1.1.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,86 +11,57 @@ jobs:
           make && ./tester
         displayName: Run unit tests
 
-  - job: python_linux
-    pool: { vmImage: "Ubuntu-16.04" }
+  - job: linux
+    pool: {vmImage: "Ubuntu-16.04"}
     steps:
       - task: UsePythonVersion@0
       - bash: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==1.1.0
           # Make the header files available to the build.
           cp *.h python
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==0.12.0
           cd python
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
-        inputs: { pathtoPublish: "python/wheelhouse" }
+        inputs: {pathtoPublish: 'python/wheelhouse'}
       - script: |
           pip install black==19.10b0
           black --check python/
         displayName: Check Python code format
 
-  - job: python_macos
-    pool: { vmImage: "macOS-10.13" }
+  - job: macos
+    pool: {vmImage: 'macOS-10.13'}
     variables:
       # Support C++11: https://github.com/joerick/cibuildwheel/pull/156
       MACOSX_DEPLOYMENT_TARGET: 10.9
     steps:
       - task: UsePythonVersion@0
       - bash: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==1.1.0
           # Make the header files available to the build.
           cp *.h python
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==0.12.0
           cd python
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
-        inputs: { pathtoPublish: "python/wheelhouse" }
+        inputs: {pathtoPublish: 'python/wheelhouse'}
 
-  - job: python_windows
-    pool: { vmImage: "vs2017-win2016" }
+  - job: windows
+    pool: {vmImage: 'vs2017-win2016'}
     steps:
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "2.7", architecture: x86 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "2.7", architecture: x64 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.5", architecture: x86 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.5", architecture: x64 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.6", architecture: x86 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.6", architecture: x64 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.7", architecture: x86 },
-        }
-      - {
-          task: UsePythonVersion@0,
-          inputs: { versionSpec: "3.7", architecture: x64 },
-        }
+      - task: UsePythonVersion@0
       - script: choco install vcpython27 -f -y
         displayName: Install Visual C++ for Python 2.7
       - bash: |
-          cp *.h python
           python -m pip install --upgrade pip
-          pip install cibuildwheel==0.12.0
+          pip install cibuildwheel==1.1.0
+          # Make the header files available to the build.
+          cp *.h python
           cd python
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
-        inputs: { pathtoPublish: "python/wheelhouse" }
+        inputs: {pathtoPublish: 'python/wheelhouse'}
+
 
 trigger:
   - master


### PR DESCRIPTION
Add support for Python 3.8.

I'm hoping this fixes the broken builds.